### PR TITLE
feat(nodeselector): Add logic to configure the nodeSelector

### DIFF
--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -14,6 +14,7 @@ export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
 
 export const ENV_HOOK_TEMPLATE_PATH = 'ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE'
 export const ENV_USE_KUBE_SCHEDULER = 'ACTIONS_RUNNER_USE_KUBE_SCHEDULER'
+export const ENV_COPY_NODE_SELECTOR_LABELS = 'ACTIONS_RUNNER_COPY_NODE_SELECTOR_LABELS'
 
 export function containerVolumes(
   userMountVolumes: Mount[] = [],
@@ -271,6 +272,19 @@ export function readExtensionFromFile(): k8s.V1PodTemplateSpec | undefined {
 
 export function useKubeScheduler(): boolean {
   return process.env[ENV_USE_KUBE_SCHEDULER] === 'true'
+}
+
+export function getCopyNodeSelectorLabels(): string[] | undefined {
+  return process.env[ENV_COPY_NODE_SELECTOR_LABELS]?.split(',')
+}
+
+export function copyNodeSelectorLabels(): boolean {
+  const nodeSelectorLabels = getCopyNodeSelectorLabels()?.length
+  if (!nodeSelectorLabels) {
+    return false
+  }
+
+  return nodeSelectorLabels > 0
 }
 
 export enum PodPhase {


### PR DESCRIPTION
This PR adds support for configuring the nodeSelector on the workflow pods.
This is only done if the kube scheduler feature is enabled as the feature would not make sense without it.

This feature is needed in order to ensure that the workflow pods schedule on the same architecture and OS as the runner pod (when running this in a multi-arch multi-os cluster).
Without the feature you could run into the issue where the pod would be scheduled on a different architecture or OS and then run into issues while running node or other tools that are copied over from the runner.

The set of labels is configurable using the `ACTIONS_RUNNER_COPY_NODE_SELECTOR_LABELS` environment variable and are comma separated.
In order to make use of this feature you'll have to grant the runner service account access to the `get` verb on the `nodes` resource (in a `ClusterRole`).

Once the feature is enabled it will fetch the labels from the node that the `runner` pod is running on and then copy the values of the specified labels (those from the environment variable) as nodeSelector