### PR TITLE
feat(container): Add logic to build an image containing the library

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,8 @@
+# Ignore all files by default
+*
+
+# Include the files that we actually need
+!packages/
+!package.json
+!package-lock.json
+!tsconfig.json

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,14 @@
+ARG BUILDPLATFORM
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:22-alpine AS builder
+
+WORKDIR /code
+COPY . .
+
+RUN npm install
+RUN npm run bootstrap
+RUN npm run build-all
+
+ARG TARGETPLATFORM
+FROM --platform=${TARGETPLATFORM} docker.io/library/busybox:1.37.0-musl
+
+COPY --from=builder /code/packages/k8s/dist/index.js index.js


### PR DESCRIPTION
This PR adds the container related files to build an image.
As the library is bigger than 1M we can't store it in a configmap in Kubernetes.
By adding these files we now have the ability to build an image with the library in it.
Instead of having to update the base runner image everytime a new version is released we can now simply use this image as an initcontainer to copy the library to an emptydir volume.

Once kubernetes adds support for OCI volumes we can simplify this even further and base the image on scratch and mount it directly into the runner container, removing the need for an init container