### PR TITLE
feat(volume): Add logic to copy the data without using a shared volume

### DIFF
--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -15,7 +15,9 @@
         "@kubernetes/client-node": "^0.22.2",
         "hooklib": "file:../hooklib",
         "js-yaml": "^4.1.0",
-        "shlex": "^2.1.2"
+        "shlex": "^2.1.2",
+        "tar": "^7.4.3",
+        "tmp-promise": "^3.0.3"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
@@ -4592,6 +4594,7 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
       "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -4647,6 +4650,24 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -8668,6 +8689,19 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="
+    },
+    "tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "requires": {
+        "tmp": "^0.2.0"
+      }
     },
     "tmpl": {
       "version": "1.0.5",

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -19,7 +19,9 @@
     "@kubernetes/client-node": "^0.22.2",
     "hooklib": "file:../hooklib",
     "js-yaml": "^4.1.0",
-    "shlex": "^2.1.2"
+    "shlex": "^2.1.2",
+    "tar": "^7.4.3",
+    "tmp-promise": "^3.0.3"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -2,8 +2,8 @@
 import * as fs from 'fs'
 import * as core from '@actions/core'
 import { RunScriptStepArgs } from 'hooklib'
-import { execPodStep } from '../k8s'
-import { writeEntryPointScript } from '../k8s/utils'
+import { cpFromPod, cpToPod, execPodStep } from '../k8s'
+import { usePodCpVolume, writeEntryPointScript } from '../k8s/utils'
 import { JOB_CONTAINER_NAME } from './constants'
 
 export async function runScriptStep(
@@ -20,6 +20,11 @@ export async function runScriptStep(
     environmentVariables
   )
 
+  if (usePodCpVolume()) {
+    core.debug('Copying the script to the work volume on the workflow pod')
+    await cpToPod(state.jobPod, JOB_CONTAINER_NAME, '/home/runner/_work/_temp/.', '/__w/_temp')
+  }
+
   args.entryPoint = 'sh'
   args.entryPointArgs = ['-e', containerPath]
   try {
@@ -34,5 +39,8 @@ export async function runScriptStep(
     throw new Error(`failed to run script step: ${message}`)
   } finally {
     fs.rmSync(runnerPath)
+
+    core.debug('Copying output files back to the runner')
+    await cpFromPod(state.jobPod, JOB_CONTAINER_NAME, '/__w/_temp/_runner_file_commands/.', '/home/runner/_work/_temp/_runner_file_commands')
   }
 }

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -15,6 +15,7 @@ export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
 export const ENV_HOOK_TEMPLATE_PATH = 'ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE'
 export const ENV_USE_KUBE_SCHEDULER = 'ACTIONS_RUNNER_USE_KUBE_SCHEDULER'
 export const ENV_COPY_NODE_SELECTOR_LABELS = 'ACTIONS_RUNNER_COPY_NODE_SELECTOR_LABELS'
+export const ENV_USE_POD_CP_VOLUME = 'ACTIONS_RUNNER_USE_POD_CP_VOLUME'
 
 export function containerVolumes(
   userMountVolumes: Mount[] = [],
@@ -285,6 +286,10 @@ export function copyNodeSelectorLabels(): boolean {
   }
 
   return nodeSelectorLabels > 0
+}
+
+export function usePodCpVolume(): boolean {
+  return process.env[ENV_USE_POD_CP_VOLUME] === 'true'
 }
 
 export enum PodPhase {


### PR DESCRIPTION
This PR adds support for running the runner without the need for a shared volume.
For now the created volume (size and storage class) are hardcoded, we'll move this to environment variables in the future (once we've had more time to test and verify everything)