### PR TITLE
feat(container): Add logic to override the job container info based on the image

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -18,7 +18,8 @@ import {
   fixArgs,
   copyNodeSelectorLabels,
   getCopyNodeSelectorLabels,
-  usePodCpVolume
+  usePodCpVolume,
+  applyContainerOverrides
 } from './utils'
 import * as fs from 'fs'
 import { WritableStreamBuffer } from 'stream-buffers'
@@ -162,6 +163,8 @@ export async function createPod(
   if (extension?.spec) {
     mergePodSpecWithOptions(appPod.spec, extension.spec)
   }
+
+  applyContainerOverrides(appPod.spec)
 
   const { body } = await k8sApi.createNamespacedPod(namespace(), appPod)
   return body


### PR DESCRIPTION
This PR adds support to configure various aspects of the container based on the image that's used.
In the future we might join the extension logic with name / image based matching (for the job container) so that we don't have to 'duplicate' the logic